### PR TITLE
Dynamic: #692 Absorbing Boundary

### DIFF
--- a/include/node.h
+++ b/include/node.h
@@ -209,6 +209,9 @@ class Node : public NodeBase<Tdim> {
   bool assign_friction_constraint(unsigned dir, int sign,
                                   double friction) override;
 
+  bool assign_absorbing_constraint(unsigned dir, int sign,
+                                  double friction) override;
+
   //! Apply friction constraints
   //! \param[in] dt Time-step
   void apply_friction_constraints(double dt) override;

--- a/include/node.h
+++ b/include/node.h
@@ -202,12 +202,13 @@ class Node : public NodeBase<Tdim> {
   void apply_velocity_constraints() override;
 
   //! Assign absorbing constraint
-  //! \param[in] pwave_v p wave velocity
-  //! \param[in] swave_v s wave velocity
-  bool assign_nodal_absorbing_constraint(double pwave_v,double swave_v);
+  //! \param[in] pwave_v P-wave velocity
+  //! \param[in] swave_v S-wave velocity
+  bool assign_absorbing_constraint(unsigned dir, double pwave_v,
+                                   double swave_v) override;
 
   //! Apply absorbing constraint
-  void apply_nodal_absorbing_constraint(double dt);
+  void apply_absorbing_constraint(double dt) override;
 
   //! Assign friction constraint
   //! Directions can take values between 0 and Dim * Nphases

--- a/include/node.h
+++ b/include/node.h
@@ -208,7 +208,7 @@ class Node : public NodeBase<Tdim> {
                                    double swave_v) override;
 
   //! Apply absorbing constraint
-  void apply_absorbing_constraint(double dt) override;
+  void apply_absorbing_constraint() override;
 
   //! Assign friction constraint
   //! Directions can take values between 0 and Dim * Nphases
@@ -309,7 +309,9 @@ class Node : public NodeBase<Tdim> {
   //! Velocity constraints
   std::map<unsigned, double> velocity_constraints_;
   //! Absorbing Constraints
-  std::map<unsigned, double> absorbing_constraints_;
+  std::tuple<unsigned, double, double> absorbing_constraints_;
+  //! Absorbing Traction
+  Eigen::Matrix<double, Tdim, Tnphases> absorbing_traction_;
   //! Rotation matrix for general velocity constraints
   Eigen::Matrix<double, Tdim, Tdim> rotation_matrix_;
   //! Material ids whose information was passed to this node

--- a/include/node.h
+++ b/include/node.h
@@ -201,15 +201,20 @@ class Node : public NodeBase<Tdim> {
   //! Apply velocity constraints
   void apply_velocity_constraints() override;
 
+  //! Assign absorbing constraint
+  //! \param[in] pwave_v p wave velocity
+  //! \param[in] swave_v s wave velocity
+  bool assign_nodal_absorbing_constraint(double pwave_v,double swave_v);
+
+  //! Apply absorbing constraint
+  void apply_nodal_absorbing_constraint(double dt);
+
   //! Assign friction constraint
   //! Directions can take values between 0 and Dim * Nphases
   //! \param[in] dir Direction of friction constraint
   //! \param[in] sign Sign of normal wrt coordinate system for friction
   //! \param[in] friction Applied friction constraint
   bool assign_friction_constraint(unsigned dir, int sign,
-                                  double friction) override;
-
-  bool assign_absorbing_constraint(unsigned dir, int sign,
                                   double friction) override;
 
   //! Apply friction constraints
@@ -302,6 +307,8 @@ class Node : public NodeBase<Tdim> {
   Eigen::Matrix<double, Tdim, Tnphases> acceleration_;
   //! Velocity constraints
   std::map<unsigned, double> velocity_constraints_;
+  //! Absorbing Constraints
+  std::map<unsigned, double> absorbing_constraints_;
   //! Rotation matrix for general velocity constraints
   Eigen::Matrix<double, Tdim, Tdim> rotation_matrix_;
   //! Material ids whose information was passed to this node

--- a/include/node.tcc
+++ b/include/node.tcc
@@ -383,25 +383,30 @@ void mpm::Node<Tdim, Tdof, Tnphases>::apply_absorbing_constraint() {
   const double swave_v = std::get<2>(this->absorbing_constraints_);
 
   // Phase: Integer value of division (dir / Tdim)
-  const auto phase_n = static_cast<unsigned>(dir_n / Tdim);
+  const unsigned phase = 0;
 
-  if (Tdim == 2) {
-    // Determine Shear Direction
-    const unsigned dir_s = (Tdim - 1) - dir_n;
-    const auto phase_s = static_cast<unsigned>(dir_s / Tdim);
+  // Create Traction Value  
+  double traction = 10;
 
-    // Calculate Traction Forces
-    double mass_density_s = mass_(phase_s) / volume_(phase_s);
-    double velocity_s = velocity_(dir_s, phase_s);
-    const double traction_s = -velocity_s * mass_density_s * swave_v;
-
-    double mass_density_n = mass_(phase_n) / volume_(phase_n);
-    double velocity_n = velocity_(dir_n, phase_n);
-    const double traction_n = -velocity_n * mass_density_n * pwave_v;
- 
-    absorbing_traction_(dir_s,phase_s) = traction_s;
-    absorbing_traction_(dir_n,phase_n) = traction_n;
+  //if (Tdim == 2) {
+  for (unsigned dir = 0; dir < Tdim; ++dir) {
+  	// Calculate Traction Forces
+	if (dir == dir_n) {
+    	double mass_density = mass_(phase) / volume_(phase);
+    	double velocity = velocity_(dir, phase);
+    	traction = -velocity * mass_density * pwave_v;
+    } else {
+    	double mass_density = mass_(phase) / volume_(phase);
+    	double velocity = velocity_(dir, phase);
+    	traction = -velocity * mass_density * swave_v;
+    }
+    // Apply traction forces
+    absorbing_traction_(dir,phase) = traction;
+  
+    //}
   }
+  // Update external force
+  this->update_external_force(true, phase, absorbing_traction_.col(phase)); 
 }
 
 //! Assign friction constraint

--- a/include/node.tcc
+++ b/include/node.tcc
@@ -350,10 +350,10 @@ void mpm::Node<Tdim, Tdof, Tnphases>::apply_velocity_constraints() {
   }
 }
 
-// bool assign_absorbing_constraints(double pwave_v, double swave_v);
-// !Assign absorbing constraints
+//! Assign absorbing constraints
 template <unsigned Tdim, unsigned Tdof, unsigned Tnphases>
-bool mpm::Node<Tdim, Tdof, Tnphases>::assign_absorbing_constraint(unsigned dir, double pwave_v, double swave_v) {
+bool mpm::Node<Tdim, Tdof, Tnphases>::assign_absorbing_constraint(
+    unsigned dir, double pwave_v, double swave_v) {
   bool status = true;
   try {
     if (dir < Tdim) {
@@ -376,37 +376,34 @@ void mpm::Node<Tdim, Tdof, Tnphases>::apply_absorbing_constraint() {
   // Extract normal direction
   const unsigned dir_n = std::get<0>(this->absorbing_constraints_);
 
-  // Extract p-wave velocity
+  // Extract P-wave velocity
   const double pwave_v = std::get<1>(this->absorbing_constraints_);
 
-  // Extract s-wave velocity
+  // Extract S-wave velocity
   const double swave_v = std::get<2>(this->absorbing_constraints_);
 
   // Phase: Integer value of division (dir / Tdim)
   const unsigned phase = 0;
 
-  // Create Traction Value  
-  double traction = 10;
+  // Create Traction Value
+  double traction;
 
-  //if (Tdim == 2) {
   for (unsigned dir = 0; dir < Tdim; ++dir) {
-  	// Calculate Traction Forces
-	if (dir == dir_n) {
-    	double mass_density = mass_(phase) / volume_(phase);
-    	double velocity = velocity_(dir, phase);
-    	traction = -velocity * mass_density * pwave_v;
+    // Get mass density and velocity
+    double mass_density = mass_(phase) / volume_(phase);
+    double velocity = velocity_(dir, phase);
+
+    // Calculate Traction Forces
+    if (dir == dir_n) {
+      traction = -velocity * mass_density * pwave_v;
     } else {
-    	double mass_density = mass_(phase) / volume_(phase);
-    	double velocity = velocity_(dir, phase);
-    	traction = -velocity * mass_density * swave_v;
+      traction = -velocity * mass_density * swave_v;
     }
     // Apply traction forces
-    absorbing_traction_(dir,phase) = traction;
-  
-    //}
+    absorbing_traction_(dir, phase) = traction;
   }
   // Update external force
-  this->update_external_force(true, phase, absorbing_traction_.col(phase)); 
+  this->update_external_force(true, phase, absorbing_traction_.col(phase));
 }
 
 //! Assign friction constraint

--- a/include/node_base.h
+++ b/include/node_base.h
@@ -193,6 +193,15 @@ class NodeBase {
   //! Apply velocity constraints
   virtual void apply_velocity_constraints() = 0;
 
+  //! Assign absorbing constraint
+  //! \param[in] pwave_v p-wave velocity
+  //! \param[in] swave_v s-wave velocity
+  virtual bool assign_absorbing_constraint(unsigned dir, double pwave_v,
+                                           double swave_v) = 0;
+
+  //! Apply absorbing constraint
+  virtual void apply_absorbing_constraint(double dt) = 0;
+
   //! Assign friction constraint
   //! Directions can take values between 0 and Dim * Nphases
   //! \param[in] dir Direction of friction constraint

--- a/include/node_base.h
+++ b/include/node_base.h
@@ -200,7 +200,7 @@ class NodeBase {
                                            double swave_v) = 0;
 
   //! Apply absorbing constraint
-  virtual void apply_absorbing_constraint(double dt) = 0;
+  virtual void apply_absorbing_constraint() = 0;
 
   //! Assign friction constraint
   //! Directions can take values between 0 and Dim * Nphases

--- a/tests/node_test.cc
+++ b/tests/node_test.cc
@@ -736,28 +736,38 @@ TEST_CASE("Node is checked for 2D case", "[node][2D]") {
         // Calculate traction and check updated external force
         for (unsigned i = 0; i < Dim; ++i) {
           if (i == direction_normal) {
-            double traction_normal = -velocity_pwave * node->velocity(Nphase)(i) * mass_density;
-            REQUIRE(node->external_force(Nphase)(i) == Approx(traction_normal).epsilon(Tolerance));
+            double traction_normal =
+                -velocity_pwave * node->velocity(Nphase)(i) * mass_density;
+            REQUIRE(node->external_force(Nphase)(i) ==
+                    Approx(traction_normal).epsilon(Tolerance));
           } else {
-            double traction_shear = -velocity_swave * node->velocity(Nphase)(i) * mass_density;
-            REQUIRE(node->external_force(Nphase)(i) == Approx(traction_shear).epsilon(Tolerance));
+            double traction_shear =
+                -velocity_swave * node->velocity(Nphase)(i) * mass_density;
+            REQUIRE(node->external_force(Nphase)(i) ==
+                    Approx(traction_shear).epsilon(Tolerance));
           }
-        } 
+        }
 
         // Check for incorrect direction
         const unsigned direction_incorrect = 4;
-        REQUIRE(node->assign_absorbing_constraint(direction_incorrect, velocity_pwave, velocity_swave) == false);
+        REQUIRE(node->assign_absorbing_constraint(direction_incorrect,
+                                                  velocity_pwave,
+                                                  velocity_swave) == false);
 
         // Check external force hasn't been updated
         for (unsigned i = 0; i < Dim; ++i) {
           if (i == direction_normal) {
-            double traction_normal = -velocity_pwave * node->velocity(Nphase)(i) * mass_density;
-            REQUIRE(node->external_force(Nphase)(i) == Approx(traction_normal).epsilon(Tolerance));
+            double traction_normal =
+                -velocity_pwave * node->velocity(Nphase)(i) * mass_density;
+            REQUIRE(node->external_force(Nphase)(i) ==
+                    Approx(traction_normal).epsilon(Tolerance));
           } else {
-            double traction_shear = -velocity_swave * node->velocity(Nphase)(i) * mass_density;
-            REQUIRE(node->external_force(Nphase)(i) == Approx(traction_shear).epsilon(Tolerance));
+            double traction_shear =
+                -velocity_swave * node->velocity(Nphase)(i) * mass_density;
+            REQUIRE(node->external_force(Nphase)(i) ==
+                    Approx(traction_shear).epsilon(Tolerance));
           }
-        } 
+        }
       }
 
       SECTION("Check concentrated force") {
@@ -1373,7 +1383,8 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
         double velocity_swave = 8000;
 
         // Assign absorbing constraint
-        REQUIRE(node->assign_absorbing_constraint(direction_normal, velocity_pwave, velocity_swave));
+        REQUIRE(node->assign_absorbing_constraint(
+            direction_normal, velocity_pwave, velocity_swave));
 
         // Calculate mass density
         double mass_density = node->mass(Nphase) / node->volume(Nphase);
@@ -1388,26 +1399,36 @@ TEST_CASE("Node is checked for 3D case", "[node][3D]") {
         // Calculate traction and check updated external force
         for (unsigned i = 0; i < Dim; ++i) {
           if (i == direction_normal) {
-            double traction_normal = -velocity_pwave * node->velocity(Nphase)(i) * mass_density;
-            REQUIRE(node->external_force(Nphase)(i) == Approx(traction_normal).epsilon(Tolerance));
+            double traction_normal =
+                -velocity_pwave * node->velocity(Nphase)(i) * mass_density;
+            REQUIRE(node->external_force(Nphase)(i) ==
+                    Approx(traction_normal).epsilon(Tolerance));
           } else {
-            double traction_shear = -velocity_swave * node->velocity(Nphase)(i) * mass_density;
-            REQUIRE(node->external_force(Nphase)(i) == Approx(traction_shear).epsilon(Tolerance));
+            double traction_shear =
+                -velocity_swave * node->velocity(Nphase)(i) * mass_density;
+            REQUIRE(node->external_force(Nphase)(i) ==
+                    Approx(traction_shear).epsilon(Tolerance));
           }
         }
 
         // Check for incorrect direction
         const unsigned direction_incorrect = 4;
-        REQUIRE(node->assign_absorbing_constraint(direction_incorrect, velocity_pwave, velocity_swave) == false);
+        REQUIRE(node->assign_absorbing_constraint(direction_incorrect,
+                                                  velocity_pwave,
+                                                  velocity_swave) == false);
 
         // Check external force hasn't been updated
         for (unsigned i = 0; i < Dim; ++i) {
           if (i == direction_normal) {
-            double traction_normal = -velocity_pwave * node->velocity(Nphase)(i) * mass_density;
-            REQUIRE(node->external_force(Nphase)(i) == Approx(traction_normal).epsilon(Tolerance));
+            double traction_normal =
+                -velocity_pwave * node->velocity(Nphase)(i) * mass_density;
+            REQUIRE(node->external_force(Nphase)(i) ==
+                    Approx(traction_normal).epsilon(Tolerance));
           } else {
-            double traction_shear = -velocity_swave * node->velocity(Nphase)(i) * mass_density;
-            REQUIRE(node->external_force(Nphase)(i) == Approx(traction_shear).epsilon(Tolerance));
+            double traction_shear =
+                -velocity_swave * node->velocity(Nphase)(i) * mass_density;
+            REQUIRE(node->external_force(Nphase)(i) ==
+                    Approx(traction_shear).epsilon(Tolerance));
           }
         }
       }


### PR DESCRIPTION
**Describe the PR**
Here is my attempt at implementing the absorbing boundary as a part of the earthquake simulation problem.

**Related Issues/PRs**
The hope is that this would apply an absorbing boundary to the left side of the simulation. My primary concerns are as to whether it will be applied in the correct direction. I am currently applying this boundary to the acceleration value, but I am unsure if this is the proper way to apply this traction.

**Additional context**
In order to get it to compile, I ended up needing to remove "override" in the node.h file. I'm not sure as to the necessity of "override" but if it is necessary, what would be the way to allow it to be implemented?

